### PR TITLE
Updated Robolectric to 2.3

### DIFF
--- a/simpleprovider/build.gradle
+++ b/simpleprovider/build.gradle
@@ -9,7 +9,9 @@ dependencies {
     compile 'com.google.android:android:4.1.1.4'
 
     testCompile 'junit:junit:4.11'
-    testCompile('org.robolectric:robolectric:2.2') {
+    testCompile('org.robolectric:robolectric:2.3') {
+        exclude module: 'support-v4'
+
         exclude module: 'classworlds'
         exclude module: 'commons-logging'
         exclude module: 'httpclient'


### PR DESCRIPTION
Removed transitive dependency to support-v4 as we don't need it for out tests.
