### PR TITLE
Fixed pluralization of strings that end with vowel+"y"

### DIFF
--- a/simpleprovider/src/main/java/de/triplet/simpleprovider/Utils.java
+++ b/simpleprovider/src/main/java/de/triplet/simpleprovider/Utils.java
@@ -24,6 +24,14 @@ final class Utils {
 
         if (string.endsWith("s")) {
             return string;
+        } else if (string.endsWith("ay")) {
+            return string.replaceAll("ay$", "ays");
+        } else if (string.endsWith("ey")) {
+            return string.replaceAll("ey$", "eys");
+        } else if (string.endsWith("oy")) {
+            return string.replaceAll("oy$", "oys");
+        } else if (string.endsWith("uy")) {
+            return string.replaceAll("uy$", "uys");
         } else if (string.endsWith("y")) {
             return string.replaceAll("y$", "ies");
         } else {

--- a/simpleprovider/src/test/java/de/triplet/simpleprovider/UtilsTest.java
+++ b/simpleprovider/src/test/java/de/triplet/simpleprovider/UtilsTest.java
@@ -16,6 +16,18 @@ public class UtilsTest {
         actual = Utils.pluralize("YTitty");
         assertThat(actual).isEqualTo(expected);
 
+        expected = "ways";
+        actual = Utils.pluralize("Way");
+        assertThat(actual).isEqualTo(expected);
+
+        expected = "boys";
+        actual = Utils.pluralize("Boy");
+        assertThat(actual).isEqualTo(expected);
+
+        expected = "journeys";
+        actual = Utils.pluralize("Journey");
+        assertThat(actual).isEqualTo(expected);
+
         expected = "beers";
         actual = Utils.pluralize("Beer");
         assertThat(actual).isEqualTo(expected);


### PR DESCRIPTION
The plural form of words that end with a vowl followed by "y" like "journey" or "way" are build by just appending an "s". So I added these special cases to the pluralize-method and added some unit test cases.
