### PR TITLE
Generate table names independent of user's locale

### DIFF
--- a/simpleprovider/src/main/java/de/triplet/simpleprovider/Utils.java
+++ b/simpleprovider/src/main/java/de/triplet/simpleprovider/Utils.java
@@ -3,6 +3,7 @@ package de.triplet.simpleprovider;
 import android.text.TextUtils;
 
 import java.lang.reflect.Field;
+import java.util.Locale;
 
 final class Utils {
 
@@ -20,7 +21,7 @@ final class Utils {
     }
 
     static String pluralize(String string) {
-        string = string.toLowerCase();
+        string = string.toLowerCase(Locale.US);
 
         if (string.endsWith("s")) {
             return string;

--- a/simpleprovider/src/test/java/de/triplet/simpleprovider/UtilsTest.java
+++ b/simpleprovider/src/test/java/de/triplet/simpleprovider/UtilsTest.java
@@ -2,6 +2,8 @@ package de.triplet.simpleprovider;
 
 import org.junit.Test;
 
+import java.util.Locale;
+
 import static org.junit.Assert.assertEquals;
 
 public class UtilsTest {
@@ -34,6 +36,21 @@ public class UtilsTest {
 
         expected = "ballantines";
         actual = Utils.pluralize("Ballantines");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void pluralizeWithDifferentLocale() {
+        String expected = "interests";
+        String actual;
+        Locale current = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr"));
+            actual = Utils.pluralize("Interest");
+        } finally {
+            Locale.setDefault(current);
+        }
+
         assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
When no explicit name is provided, always use the US locale to lowercase
the class name, otherwise the table names can change when the user
changes their locale.

The US Locale is used in lieu of an explicit invariant Locale, as per
Android recommendations:
https://developer.android.com/reference/java/util/Locale.html#default_locale