### PR TITLE
Convert to android library module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,1 +1,20 @@
 // Common parts
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.2.3'
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Nov 01 21:09:39 CET 2014
+#Thu Jul 30 19:36:59 NZST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/simpleprovider-sample/build.gradle
+++ b/simpleprovider-sample/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.14.+'
+        classpath 'com.android.tools.build:gradle:1.2.3'
     }
 }
 

--- a/simpleprovider-sample/build.gradle
+++ b/simpleprovider-sample/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
-    }
-}
-
 apply plugin: 'com.android.application'
 
 repositories {

--- a/simpleprovider/build.gradle
+++ b/simpleprovider/build.gradle
@@ -1,13 +1,65 @@
-apply plugin: 'java'
+apply plugin: 'com.android.library'
 apply plugin: 'jacoco'
+
+android {
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
+
+    defaultConfig {
+        minSdkVersion 9
+        targetSdkVersion 22
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+// Define coverage source.
+// If you have rs/aidl etc... add them here.
+def coverageSourceDirs = [
+        'src/main/java',
+]
+
+jacoco {
+    toolVersion "0.7.1.201405082137"
+}
+
+// From: http://stackoverflow.com/a/24231246
+task jacocoTestReport(type: JacocoReport, dependsOn: "testDebug") {
+    group = "Reporting"
+    description = "Generate Jacoco coverage reports after running tests."
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+    classDirectories = fileTree(
+            dir: './build/intermediates/classes/debug',
+            excludes: ['**/R*.class',
+                       '**/*$InjectAdapter.class',
+                       '**/*$ModuleAdapter.class',
+                       '**/*$ViewInjector*.class'
+            ])
+    sourceDirectories = files(coverageSourceDirs)
+    executionData = files("$buildDir/jacoco/testDebug.exec")
+    // Bit hacky but fixes https://code.google.com/p/android/issues/detail?id=69174.
+    // We iterate through the compiled .class tree and rename $$ to $.
+    doFirst {
+        new File("$buildDir/intermediates/classes/").eachFileRecurse { file ->
+            if (file.name.contains('$$')) {
+                file.renameTo(file.path.replace('$$', '$'))
+            }
+        }
+    }
+}
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile 'com.google.android:android:4.1.1.4'
-
     testCompile 'junit:junit:4.11'
     testCompile('org.robolectric:robolectric:2.3') {
         exclude module: 'support-v4'
@@ -37,10 +89,8 @@ version = VERSION_NAME
 jacocoTestReport {
     group = "Reporting"
     description = "Generate Jacoco coverage reports after running tests."
-    additionalSourceDirs = files(sourceSets.main.allJava.srcDirs)
+    additionalSourceDirs = files(android.sourceSets.main.java.srcDirs)
 }
-
-jar.dependsOn test
 
 apply from: 'gradle-mvn-push.gradle'
 
@@ -71,3 +121,4 @@ afterEvaluate { project ->
         }
     }
 }
+

--- a/simpleprovider/gradle-mvn-push.gradle
+++ b/simpleprovider/gradle-mvn-push.gradle
@@ -76,7 +76,6 @@ afterEvaluate { project ->
                         }
                     }
                 }
-
             }
         }
     }
@@ -86,18 +85,23 @@ afterEvaluate { project ->
         sign configurations.archives
     }
 
-    task javadocsJar(type: Jar, dependsOn: javadoc) {
-        classifier = 'javadoc'
-        from javadoc.destinationDir
+    task androidJavadocs(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     }
 
-    task sourcesJar(type: Jar) {
+    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+        classifier = 'javadoc'
+        from androidJavadocs.destinationDir
+    }
+
+    task androidSourcesJar(type: Jar) {
         classifier = 'sources'
-        from sourceSets.main.allJava
+        from android.sourceSets.main.java.sourceFiles
     }
 
     artifacts {
-        archives sourcesJar
-        archives javadocsJar
+        archives androidSourcesJar
+        archives androidJavadocsJar
     }
 }

--- a/simpleprovider/src/main/AndroidManifest.xml
+++ b/simpleprovider/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="de.triplet.simpleprovider">
+
+    <application>
+
+    </application>
+
+</manifest>

--- a/simpleprovider/src/main/java/de/triplet/simpleprovider/AbstractProvider.java
+++ b/simpleprovider/src/main/java/de/triplet/simpleprovider/AbstractProvider.java
@@ -57,12 +57,12 @@ public abstract class AbstractProvider extends ContentProvider {
     /**
      * Called when the database needs to be updated and after <code>AbstractProvider</code> has
      * done its own work. That is, after creating columns that have been added using the
-     * {@link Column#since()} key.<br />
-     * <br />
+     * {@link Column#since()} key.<br>
+     * <br>
      * For example: Let <code>AbstractProvider</code> automatically create new columns. Afterwards,
      * do more complicated work like calculating default values or dropping other columns inside
-     * this method.<br />
-     * <br />
+     * this method.<br>
+     * <br>
      * This method executes within a transaction. If an exception is thrown, all changes will
      * automatically be rolled back.
      *


### PR DESCRIPTION
Based on #18 this will convert the simple-provider project to an android library module. 

This allows consuming apps to use a different min and max sdk from the
Library project. The library project has been converted to use a min sdk
of 9. Version 8cfffbbff6b9094af1c92318ea5d5a5bb0b8bb30 of
gradle-mvn-push was also used at it contains fixes for android library
projects and it has been modified to remove the developers section as
the existing gradle files set this already.